### PR TITLE
LMB-611 | Update dev compose with dev harvester

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -2,20 +2,27 @@ services:
   consumer-0:
     restart: 'no'
     environment:
+      DCR_SYNC_BASE_URL: 'https://dev.harvesting-self-service.lblod.info/' # QA endpoint
       DCR_CRON_PATTERN_DELTA_SYNC: '0/15 * * * * *'
       DCR_START_FROM_DELTA_TIMESTAMP: '2024-01-12T15:51:23.478Z'
   consumer-1:
     restart: 'no'
+    profiles:
+      - qaConsumer-1
     environment:
       DCR_CRON_PATTERN_DELTA_SYNC: '0/15 * * * * *'
       DCR_START_FROM_DELTA_TIMESTAMP: '2024-01-12T15:51:23.478Z'
   consumer-2:
     restart: 'no'
+    profiles:
+      - qaConsumer-2
     environment:
       DCR_CRON_PATTERN_DELTA_SYNC: '0/15 * * * * *'
       DCR_START_FROM_DELTA_TIMESTAMP: '2024-01-12T15:51:23.478Z'
   consumer-3:
     restart: 'no'
+    profiles:
+      - qaConsumer-3
     environment:
       DCR_CRON_PATTERN_DELTA_SYNC: '0/15 * * * * *'
       DCR_START_FROM_DELTA_TIMESTAMP: '2024-01-12T15:51:23.478Z'

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -2,7 +2,7 @@ services:
   consumer-0:
     restart: 'no'
     environment:
-      DCR_SYNC_BASE_URL: 'https://dev.harvesting-self-service.lblod.info/' # QA endpoint
+      DCR_SYNC_BASE_URL: 'https://dev.harvesting-self-service.lblod.info/'
       DCR_CRON_PATTERN_DELTA_SYNC: '0/15 * * * * *'
       DCR_START_FROM_DELTA_TIMESTAMP: '2024-01-12T15:51:23.478Z'
   consumer-1:


### PR DESCRIPTION
## Description

Before we did not have the endpoint for the dev harvester of lokaal beslist. Now e do we can update the dev compose file with this url: `https://dev.harvesting-self-service.lblod.info/`. Override the consumer-0 endpoint to use this dev url instead of the qa/prod environment. Set a profile on the other consumers to disable these when running as development.

## How to test

1. `compose kill && compose rm`
2. Remove all data from the `./data` folder 
3. Run the app again with `compose up -d && compose logs -f consumer-0`
4. You should see that the consumers 1 -3 are not started