### PR TITLE
LMB-612 | Add healing options to the exported type

### DIFF
--- a/config/delta-producer/mandatees-decisions/export.json
+++ b/config/delta-producer/mandatees-decisions/export.json
@@ -26,6 +26,12 @@
       "healingOptions": {
         "http://data.europa.eu/eli/ontology#title": {
           "queryChunkSize": 100000
+        },
+        "http://data.europa.eu/eli/ontology#number": {
+          "queryChunkSize": 50000
+        },
+        "http://www.w3.org/ns/prov#value": {
+          "queryChunkSize": 50000
         }
       }
     },


### PR DESCRIPTION
## Description

Not all data was added to the publication triplestore. We added more healing options in the export to handle the bigger values in more chunks so it does not skip our predicates.

## How to test

Run it! And look at the publication triplestore for type artikel and the distinct predicates.