### PR TITLE
Lmb 1184 derived from as linkt to besluit

### DIFF
--- a/config/ldes-delta-pusher/ldes-instances.ts
+++ b/config/ldes-delta-pusher/ldes-instances.ts
@@ -34,11 +34,13 @@ export const officialPredicates = {
     "http://data.vlaanderen.be/ns/mandaat#bekrachtigtOntslagVan",
     "http://data.europa.eu/eli/ontology#date_publication",
     "http://data.europa.eu/eli/ontology#title",
+    "http://www.w3.org/ns/prov#wasDerivedFrom",
   ],
   "http://data.vlaanderen.be/ns/besluit#Besluit": [
     "http://data.vlaanderen.be/ns/mandaat#bekrachtigtAanstellingVan",
     "http://data.vlaanderen.be/ns/mandaat#bekrachtigtOntslagVan",
     "http://data.europa.eu/eli/ontology#date_publication",
     "http://data.europa.eu/eli/ontology#title",
+    "http://www.w3.org/ns/prov#wasDerivedFrom",
   ],
 };

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -131,7 +131,7 @@ services:
     labels:
       - logging=true
   ldes-delta-pusher:
-    image: redpencil/ldes-delta-pusher:1.1.3
+    image: redpencil/ldes-delta-pusher:1.2.0
     environment:
       LDES_ENDPOINT: http://ldes-backend
       LDES_BASE: https://mandaten-besluiten.lblod.info/streams/ldes


### PR DESCRIPTION
## Description

Also put the drived from triple to the ldes stream so we can pick it up in the mandataris service and use it in the frontend.

## How to test

Run this app with the dev harvester and it should add the derivedFrom triples in the ldes-feed folder

## Links to other PR's

- https://github.com/lblod/frontend-lokaal-mandatenbeheer/pull/444
- https://github.com/lblod/app-lokaal-mandatenbeheer/pull/329
